### PR TITLE
Use https for assets (un-break v2 demo)

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -12,8 +12,8 @@
   <meta name="apple-mobile-web-app-status-bar-style"
         content="black-translucent"/>
 
-  <link rel="icon" 
-      type="image/png" 
+  <link rel="icon"
+      type="image/png"
       href="favicon.png">
 
   <!--
@@ -22,8 +22,8 @@
   S T Y L E S H E E T S
 
   -->
-  <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro:300,400,500,600,700,800,900' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,500,600,700,800,900' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:300,400,500,600,700,800,900' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,500,600,700,800,900' rel='stylesheet' type='text/css'>
 
   <link rel="stylesheet" href="style/codemirror-tweaked.css">
   <link rel="stylesheet" href="style/theme.css">
@@ -63,9 +63,9 @@
   S C R I P T S
 
   -->
-  
+
   <!-- libs -->
-  <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+  <script src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
   <script src="script/husl.js"></script>
 
   <!-- CodeMirror -->


### PR DESCRIPTION
The v2 demo is currently broken because it tries to load assets over http.